### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 elasticsearch==5.4.0
 lxml
-Scrapy==2.6.2
+Scrapy==2.6.3
 toolz<1.0
 loguru
 dvc[gs]


### PR DESCRIPTION
Bump Scrapy to 2.6.3, which resolves the `AttributeError: module 'OpenSSL.SSL' has no attribute 'SSLv3_METHOD'` error that resulted from a recent update to the PyOpenSSL package.