### PR TITLE
Solving recent changes at nuforc.org

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -6,8 +6,9 @@ stages:
     - cp data/raw/nuforc_reports.json data/raw/nuforc_reports_orig.json
     outs:
     - path: data/raw/nuforc_reports_orig.json
-      md5: 56039b24b50b22bfb030a6a075c731b6
-      size: 219661245
+      hash: md5
+      md5: d41d8cd98f00b204e9800998ecf8427e
+      size: 0
   unzip-cities:
     cmd:
     - unzip -o data/external/GeoLite2-City-CSV.zip -d data/external/
@@ -15,74 +16,87 @@ stages:
     - mv -f data/external/GeoLite2-City-CSV_* data/external/geolite_city
     deps:
     - path: data/external/GeoLite2-City-CSV.zip
-      md5: 2f97146b0988a2ec5173e5760816dfb8
-      size: 50285930
+      hash: md5
+      md5: 75c200d1d25ff734c0f3e760ffc4dc13
+      size: 53499758
     outs:
     - path: data/external/geolite_city/GeoLite2-City-Blocks-IPv4.csv
-      md5: 3d318c442192378530b2abef39394fe6
-      size: 225187559
+      hash: md5
+      md5: 4364dd2b41bce807d09812a2d688f43e
+      size: 232519664
     - path: data/external/geolite_city/GeoLite2-City-Locations-en.csv
-      md5: d4a62e2613bbd84b91e2cf8a4483f92d
-      size: 10500345
+      hash: md5
+      md5: 34fbddc007df00f135de95d71cf92025
+      size: 10242394
   make-cities:
     cmd:
     - python scripts/make_cities.py data/external/geolite_city/GeoLite2-City-Locations-en.csv
       data/external/geolite_city/GeoLite2-City-Blocks-IPv4.csv --output-file data/external/cities.csv
     deps:
     - path: data/external/geolite_city/GeoLite2-City-Blocks-IPv4.csv
-      md5: 3d318c442192378530b2abef39394fe6
-      size: 225187559
+      hash: md5
+      md5: 4364dd2b41bce807d09812a2d688f43e
+      size: 232519664
     - path: data/external/geolite_city/GeoLite2-City-Locations-en.csv
-      md5: d4a62e2613bbd84b91e2cf8a4483f92d
-      size: 10500345
+      hash: md5
+      md5: 34fbddc007df00f135de95d71cf92025
+      size: 10242394
     - path: scripts/make_cities.py
       md5: f46af8dbf6a3b8142be74a2584b001fe
       size: 1217
     outs:
     - path: data/external/cities.csv
-      md5: 86c9047b80e68102fc8d19376b7b4c22
-      size: 6570447
+      hash: md5
+      md5: fe1fa97bdf8d3f4c6859c1aebb12cef7
+      size: 6484862
   pull-new-reports:
     cmd:
     - cd nuforc_reports && scrapy crawl nuforc_report_spider --output $(dvc root)/data/raw/nuforc_reports_new.json
       --output-format jsonlines
     outs:
     - path: data/raw/nuforc_reports_new.json
-      md5: 008eb3929e866d62dc34a0e4a61b32d6
-      size: 224213664
+      hash: md5
+      md5: fb6708d54ddf87a4282b7b9160031da4
+      size: 85756101
   merge-reports:
     cmd:
     - python scripts/union_nuforc_reports.py data/raw/nuforc_reports_orig.json data/raw/nuforc_reports_new.json
       data/raw/nuforc_reports.json
     deps:
     - path: data/raw/nuforc_reports_new.json
-      md5: 008eb3929e866d62dc34a0e4a61b32d6
-      size: 224213664
+      hash: md5
+      md5: fb6708d54ddf87a4282b7b9160031da4
+      size: 85756101
     - path: data/raw/nuforc_reports_orig.json
-      md5: 56039b24b50b22bfb030a6a075c731b6
-      size: 219661245
+      hash: md5
+      md5: d41d8cd98f00b204e9800998ecf8427e
+      size: 0
     - path: scripts/union_nuforc_reports.py
       md5: d14437b7531198ddf7e12cbd61929450
       size: 1130
     outs:
     - path: data/raw/nuforc_reports.json
-      md5: 50e3f0b6dd1ba5f195111251fb78ecd6
-      size: 224216951
+      hash: md5
+      md5: fb6708d54ddf87a4282b7b9160031da4
+      size: 85756101
   geocode-reports:
     cmd:
     - python scripts/process_report_data.py data/raw/nuforc_reports.json data/external/cities.csv
       --output-file data/processed/nuforc_reports.csv
     deps:
     - path: data/external/cities.csv
-      md5: 86c9047b80e68102fc8d19376b7b4c22
-      size: 6570447
+      hash: md5
+      md5: fe1fa97bdf8d3f4c6859c1aebb12cef7
+      size: 6484862
     - path: data/raw/nuforc_reports.json
-      md5: 50e3f0b6dd1ba5f195111251fb78ecd6
-      size: 224216951
+      hash: md5
+      md5: fb6708d54ddf87a4282b7b9160031da4
+      size: 85756101
     - path: scripts/process_report_data.py
       md5: 03fd59b015bf15dea56ea4270ae835bb
       size: 7717
     outs:
     - path: data/processed/nuforc_reports.csv
-      md5: d8e712aa3d37e2d3f71a634134067eec
-      size: 208624171
+      hash: md5
+      md5: 254e63f4c77aaf7b9eefdcd819d39888
+      size: 77565215

--- a/nuforc_reports/nuforc_reports/spiders/nuforc_report_spider.py
+++ b/nuforc_reports/nuforc_reports/spiders/nuforc_report_spider.py
@@ -4,8 +4,8 @@ from datetime import datetime
 
 class NuforcReportSpider(scrapy.Spider):
     name = 'nuforc_report_spider'
-    allowed_domains = ['www.nuforc.org']
-    start_urls = ['http://www.nuforc.org/webreports/ndxpost.html']
+    allowed_domains = ['www.nuforc.org', 'nuforc.org']
+    start_urls = ['https://www.nuforc.org/ndx/?id=post']
 
     def __init__(self, start_date=None, stop_date=None, *args, **kwargs):
         self.start_date = \
@@ -14,14 +14,12 @@ class NuforcReportSpider(scrapy.Spider):
         self.stop_date = \
             datetime.strptime(stop_date, '%m/%d/%Y') \
             if stop_date else None
-
         super(NuforcReportSpider, self).__init__(*args, **kwargs)
 
     def parse(self, response):
         
-        table_links = response.xpath('//tr/td/a')
+        table_links = response.xpath('//tr/td/u/a')
         for tl in table_links:
-
             # Guard against empty rows.
             if not tl: continue
 
@@ -33,15 +31,15 @@ class NuforcReportSpider(scrapy.Spider):
 
             # If that's extracted, parse and check the date.
             link_date = \
-                datetime.strptime(link_date_selector.extract()[0], '%m/%d/%Y')
-            
+                datetime.strptime(link_date_selector.extract()[0], '%Y-%m-%d')
             # If link date is less than the start date, skip.
             if self.start_date and (link_date < self.start_date): continue
 
             # If link date is greater than or equal to the stop date, skip.
             if self.stop_date and (link_date >= self.stop_date): continue
+            url = tl.xpath("@href").get()
 
-            yield response.follow(tl, self.parse_date_index)
+            yield response.follow('https://nuforc.org' + url, self.parse_date_index)
 
     def parse_date_index(self, response):
 
@@ -51,47 +49,48 @@ class NuforcReportSpider(scrapy.Spider):
         # Extract this and pass it to the next request as metadata.
         for tr in table_rows:
             table_elements = tr.xpath('.//td')
-            date_time_path = table_elements[0] \
+            date_time_path = table_elements[1] \
                 if len(table_elements) > 0 else None
+
             
             # If the date time path can't be extracted, skip this row.
             if not date_time_path: continue
             
-            date_time = date_time_path.xpath('./a/text()').extract() \
+            date_time = date_time_path.xpath('./text()').get() \
                 if date_time_path else None
-            report_link = date_time_path.xpath('./a/@href').extract() \
-                if date_time_path else None
-            city = table_elements[1].xpath('./text()').extract() \
+
+            report_link =  table_elements[0].xpath('./a/@href').get() \
+                if table_elements[0] else None
+            city = table_elements[2].xpath('./text()').extract() \
                 if len(table_elements) > 1 else None
-            state = table_elements[2].xpath('./text()').extract() \
+            state = table_elements[3].xpath('./text()').extract() \
                 if len(table_elements) > 2 else None
-            country = table_elements[3].xpath('./text()').extract() \
+            country = table_elements[4].xpath('./text()').extract() \
                 if len(table_elements) > 3 else None
-            shape = table_elements[4].xpath('./text()').extract() \
+            shape = table_elements[5].xpath('./text()').extract() \
                 if len(table_elements) > 4 else None
-            duration = table_elements[5].xpath('./text()').extract() \
-                if len(table_elements) > 5 else None
+#            duration = table_elements[5].xpath('./text()').extract() \
+#                if len(table_elements) > 5 else None
+#            duration = 0
             summary = table_elements[6].xpath('./text()').extract() \
-                if len(table_elements) > 6 else None
-            posted = table_elements[7].xpath('./text()').extract() \
+                if len(table_elements) > 5 else None
+            posted = table_elements[8].xpath('./text()').extract() \
                 if len(table_elements) > 7 else None
 
             # Passing the summary table contents as metadata so the report 
             # request has access.
             yield response.follow(
-                date_time_path.xpath("./a")[0],
+                report_link,
                 self.parse_report_table,
                 meta={
                     "report_summary": {
-                        "date_time": date_time[0] if date_time else None,
-                        "report_link": 
-                            "http://www.nuforc.org/webreports/{}".format(
-                                report_link[0]) if report_link else None,
+                        "date_time": date_time if date_time else None,
+                        "report_link": f"http://www.nuforc.org{report_link}" if report_link else None, 
                         "city": city[0] if city else None,
                         "state": state[0] if state else None,
                         "country": country[0] if country else None,
                         "shape": shape[0] if shape else None,
-                        "duration": duration[0] if duration else None,
+ #                       "duration": duration[0] if duration else None,
                         "summary": summary[0] if summary else None,
                         "posted": posted[0] if posted else None
                     }
@@ -100,22 +99,23 @@ class NuforcReportSpider(scrapy.Spider):
 
     def parse_report_table(self, response):
 
-        report_table = response.xpath('//table/tbody/tr')
+        #report is not a table anymore
+        report_area = response.xpath('//div[contains(@class, "content-area clr")]')
 
         # The first row is a rehash (sort of) of the table summary.
         # Included for completeness.
-        report_stats = \
-            " ".join(report_table[0].xpath('./td/font/text()').extract()) \
-            if len(report_table) > 0 else None
-        # The second row is the text of the report.
-        report_text = \
-            " ".join(report_table[1].xpath('./td/font/text()').extract()) \
-            if len(report_table) > 1 else None
+        report_data = { k : v for k,v in zip([x.split(":")[0] for x in report_area.xpath('//div[contains(@class, "content-area clr")]//b/text()').getall()], \
+                                     [x for x in [x.strip() for x in report_area.xpath('//div[contains(@class, "content-area clr")]/text()').getall()] if x != '']) }
+        report_zip = zip([x.split(":")[0] for x in report_area.xpath('//div[contains(@class, "content-area clr")]//b/text()').getall()], \
+                                     [x for x in [x.strip() for x in report_area.xpath('//div[contains(@class, "content-area clr")]/text()').getall()] if x != ''])
+        report_text = " ".join([x.strip() for x in report_area.xpath('//div[contains(@class, "content-area clr")]/text()').getall()][9:])
+        
         report_summary = response.meta["report_summary"]
     
         report = {
-            "text": report_text,
-            "stats": report_stats,
+            "text"    : report_text,
+            "duration": report_data["Duration"] if 'Duration' in report_data else None,
+            "stats"   : "|".join([str(k)+":"+str(v) for k,v in report_zip]),
             **report_summary
         }
 


### PR DESCRIPTION
This commit solves several issues caused by change in page format at nuforc

1. the HTML of all pages have been modified
2. date format in by posted  page has been changed
3. data table has been moved in by posted  page
4. duration is not available anymore in the date index page
5. table in  page was removed. Now data is free formatted HTML

I have made a fork and checked in changes to resolve all those problems.

https://github.com/valerioa/nuforc_sightings_data

Now everything runs smoothly and data is processed correctly.

I refactored the code to adapt it to the nuforc changes. I have found a way to structure the unstructured data of the stats page. Duration is now taken from the stats page.

Data should be compatible with the previous version. The only thing I changed is the formatting of the stats column.

The stat column now is pipe delimited with <field name> and <value> separated by a colon. This is for ease of further parsing and analysis.

`<field name>:<value>|<field name>:<value>|<field name>:<value>|<field name>:<value>|`

example:

"Occurred:2021-08-19 18:00:00 Local|Location:Dallas, TX, USA|Shape:Unknown|Duration:2 minutes|No of observers:2|Reported:2021-08-20 12:49:56 Pacific|Posted:2021-08-20 00:00:00|Characteristics:Lights on object, Aura or haze around object, Aircraft nearby"